### PR TITLE
Added a github userscript

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ There's no focused plugins to get Userscripts running on Internet Explorer, but 
 * [Github News Feed Filter](https://github.com/jerone/UserScripts/tree/master/Github_News_Feed_Filter#readme) - Add filters for Github homepage news feed items.
 * [Github Pull Request From Link](https://github.com/jerone/UserScripts/tree/master/Github_Pull_Request_From#readme) - Make pull request branches linkable.
 * [Github Pages Linker](https://github.com/jerone/UserScripts/tree/master/Github_Pages_Linker#readme) - Add a link to Github Pages (gh-pages) when available.
-
+* [Github Skip Delete Repo Verification](https://greasyfork.org/en/scripts/411790-skip-delete-repo-verification) - Skips the verification step when deleting a repository.
 
 ### Google
 


### PR DESCRIPTION
It skips the verification step when deleting a repository where you have to type in the repo name.